### PR TITLE
Refactor: week04 리팩토링 완료 - 페페

### DIFF
--- a/week04/pepe/week04_pepe/week04_pepe/ContentArea.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/ContentArea.swift
@@ -8,96 +8,151 @@
 import SwiftUI
 
 struct ContentArea: View {
+    // View의 본문을 정의함.
     var body: some View {
+        // 스크롤 가능한 뷰를 생성함.
         ScrollView {
-            VStack {
-                Image("ImgContentL01")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .overlay {
+            // 첫 번째 이미지를 표시함.
+            Image("ImgContentL01")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .overlay {
+                    VStack {
+                        // 이미지 위에 텍스트를 겹침.
+                        Text("채드도 놀란")
+                            .font(.system(size: 20))
+                            .fontWeight(.bold)
+                        Text("iPhone 14 Pro")
+                            .font(.system(size: 30))
+                            .fontWeight(.bold)
+                        // 공간을 채움.
+                        Spacer()
+                    }
+                    // 텍스트 위 여백을 40으로 설정함.
+                    .padding(.top, 40)
+                    .foregroundColor(FontColor.white.color)
+            }
+            // 두 번째 이미지를 표시함.
+            Image("ImgContentL02")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .overlay {
+                    VStack {
+                        // 이미지 위에 텍스트를 겹침.
+                        Text("Dynamic Island")
+                            .font(.system(size: 20))
+                            .fontWeight(.bold)
+                        Text("iPhone을 다루는 완전히")
+                            .font(.system(size: 30))
+                            .fontWeight(.bold)
+                        Text("새로운 방법.")
+                            .font(.system(size: 30))
+                            .fontWeight(.bold)
+                        // 공간을 채움.
+                        Spacer()
+                    }
+                    // 텍스트 위 여백을 40으로 설정함.
+                    .padding(.top, 40)
+                    .foregroundColor(FontColor.gray.color)
+            }
+            // 세 번째 이미지를 표시함.
+            Image("ImgContentSm01")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .overlay {
+                    HStack {
+                        // 이미지 위에 텍스트를 겹침.
                         VStack {
-                            Text("채드도 놀란")
-                                .font(.system(size: 20))
-                                .fontWeight(.bold)
-                                .foregroundColor(FontColor.white.color)
-                            Text("iPhone 14 Pro")
+                            Text("그 모든 걸\n가능케 하는\n브레인.")
                                 .font(.system(size: 30))
                                 .fontWeight(.bold)
-                                .foregroundColor(FontColor.white.color)
+                            // 공간을 채움.
                             Spacer()
                         }
-                        .padding(.top, 40)
+                        // 공간을 채움.
+                        Spacer()
                     }
-                
-                Image("ImgContentL02")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .overlay {
-                        VStack {
-                            Text("ProMotion으로 선명한 세상을 만나보세요.")
-                                .font(.system(size: 20))
-                                .fontWeight(.bold)
-                                .foregroundColor(FontColor.white.color)
-                            Text("120Hz의 ProMotion 기술로 더욱 매끄럽고 빠른 화면을 경험하세요.")
-                                .font(.system(size: 16))
-                                .foregroundColor(FontColor.white.color)
-                            Spacer()
-                        }
-                        .padding(.top, 40)
-                    }
-                
-                Image("ImgContentL03")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .overlay {
-                        VStack {
-                            Text("그 무엇보다 강력한 카메라.")
-                                .font(.system(size: 20))
-                                .fontWeight(.bold)
-                                .foregroundColor(FontColor.white.color)
-                            Text("더욱 업그레이드된 카메라로 그 어떤 순간도 놓치지 마세요.")
-                                .font(.system(size: 16))
-                                .foregroundColor(FontColor.white.color)
-                            Spacer()
-                        }
-                        .padding(.top, 40)
-                    }
-                
-                Image("ImgContentL04")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .overlay {
-                        VStack {
-                            Text("더욱 강력해진 A16 칩.")
-                                .font(.system(size: 20))
-                                .fontWeight(.bold)
-                                .foregroundColor(FontColor.white.color)
-                            Text("더욱 빠르고, 더욱 효율적인 A16 Bionic.")
-                                .font(.system(size: 16))
-                                .foregroundColor(FontColor.white.color)
-                            Spacer()
-                        }
-                        .padding(.top, 40)
-                    }
-                
-                Image("ImgContentL05")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .overlay {
-                        VStack {
-                            Text("더욱 빠르게, 더욱 편리하게.")
-                                .font(.system(size: 20))
-                                .fontWeight(.bold)
-                                .foregroundColor(FontColor.white.color)
-                            Text("5G의 빠른 속도와 iOS 16의 편의성을 만나보세요.")
-                                .font(.system(size: 16))
-                                .foregroundColor(FontColor.white.color)
-                            Spacer()
-                        }
-                        .padding(.top, 40)
+                    // 텍스트 위와 좌측 여백을 각각 40으로 설정함.
+                    .padding(.top, 40)
+                    .padding(.leading, 40)
+                    .foregroundStyle(LinearGradient(
+                        colors: [FontColor.purpleStart.color, FontColor.purpleEnd.color], startPoint: .top, endPoint: .bottom
+                    ))
+            }
+            // 네 번째 이미지를 표시함.
+            Image("ImgContentSm02")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .overlay {
+                    VStack {
+                        // 이미지 위에 텍스트를 겹침.
+                        Text("오래 가는 배터리")
+                            .font(.system(size: 22))
+                            .fontWeight(.bold)
+                            .foregroundStyle(LinearGradient(
+                                colors: [FontColor.purpleStart.color, FontColor.purpleEnd.color], startPoint: .top, endPoint: .bottom
+                            ))
+                        Text("온종일,")
+                            .font(.system(size: 54))
+                            .fontWeight(.bold)
+                            .foregroundStyle(LinearGradient(
+                                colors: [FontColor.purpleStart.color, FontColor.purpleEnd.color], startPoint: .top, endPoint: .bottom
+                            ))
+                        Text("올인.")
+                            .font(.system(size: 54))
+                            .fontWeight(.bold)
+                            .foregroundStyle(LinearGradient(
+                                colors: [FontColor.purpleStart.color, FontColor.purpleEnd.color], startPoint: .top, endPoint: .bottom
+                            ))
                     }
             }
+            // 다섯 번째 이미지를 표시함.
+            Image("ImgContentL03")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .overlay {
+                    VStack {
+                        // 이미지 위에 텍스트를 겹침.
+                        Text("상시표시형 디스플레이.\n잠긴 동안에도\n잠드는 법 없이.")
+                        // 공간을 채움.
+                        Spacer()
+                    }
+                    // 텍스트 위 여백을 40으로 설정함.
+                    .padding(.top, 40)
+                    .font(.system(size: 24))
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(LinearGradient(
+                        colors: [FontColor.purpleStart.color, FontColor.purpleEnd.color], startPoint: .top, endPoint: .bottom
+                    ))
+            }
+            // 여섯 번째 이미지를 표시함.
+            Image("ImgContentL04")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .overlay {
+                    VStack {
+                        // 이미지 위에 텍스트를 겹침.
+                        Text("Ceramic Shield")
+                            .font(.system(size: 20))
+                            .fontWeight(.bold)
+                            .foregroundColor(FontColor.gray.color)
+                        Text("그 어떤 스마트폰\n글래스보다 견고한 소재.")
+                            .font(.system(size: 24))
+                            .fontWeight(.bold)
+                            .multilineTextAlignment(.center)
+                            .foregroundStyle(LinearGradient(
+                                colors: [FontColor.purpleStart.color, FontColor.purpleEnd.color], startPoint: .top, endPoint: .bottom
+                            ))
+                        // 공간을 채움.
+                        Spacer()
+                    }
+                    // 텍스트 위 여백을 40으로 설정함.
+                    .padding(.top, 40)
+                    .foregroundColor(FontColor.white.color)
+            }
         }
+        // 배경색을 설정함.
         .background(BgColor.black.color)
     }
 }

--- a/week04/pepe/week04_pepe/week04_pepe/ContentArea.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/ContentArea.swift
@@ -8,152 +8,97 @@
 import SwiftUI
 
 struct ContentArea: View {
-    // View의 본문을 정의함.
     var body: some View {
-        // 스크롤 가능한 뷰를 생성함.
         ScrollView {
-            // 첫 번째 이미지를 표시함.
-            Image("ImgContentL01")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .overlay {
-                    VStack {
-                        // 이미지 위에 텍스트를 겹침.
-                        Text("채드도 놀란")
-                            .font(.system(size: 20))
-                            .fontWeight(.bold)
-                        Text("iPhone 14 Pro")
-                            .font(.system(size: 30))
-                            .fontWeight(.bold)
-                        // 공간을 채움.
-                        Spacer()
-                    }
-                    // 텍스트 위 여백을 40으로 설정함.
-                    .padding(.top, 40)
-                    .foregroundColor(Color("ColorFontWhite"))
-            }
-            // 두 번째 이미지를 표시함.
-            Image("ImgContentL02")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .overlay {
-                    VStack {
-                        // 이미지 위에 텍스트를 겹침.
-                        Text("Dynamic Island")
-                            .font(.system(size: 20))
-                            .fontWeight(.bold)
-                        Text("iPhone을 다루는 완전히")
-                            .font(.system(size: 30))
-                            .fontWeight(.bold)
-                        Text("새로운 방법.")
-                            .font(.system(size: 30))
-                            .fontWeight(.bold)
-                        // 공간을 채움.
-                        Spacer()
-                    }
-                    // 텍스트 위 여백을 40으로 설정함.
-                    .padding(.top, 40)
-                    .foregroundColor(Color("ColorFontGray"))
-            }
-            // 세 번째 이미지를 표시함.
-            Image("ImgContentSm01")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .overlay {
-                    HStack {
-                        // 이미지 위에 텍스트를 겹침.
+            VStack {
+                Image("ImgContentL01")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .overlay {
                         VStack {
-                            Text("그 모든 걸\n가능케 하는\n브레인.")
+                            Text("채드도 놀란")
+                                .font(.system(size: 20))
+                                .fontWeight(.bold)
+                                .foregroundColor(FontColor.white.color)
+                            Text("iPhone 14 Pro")
                                 .font(.system(size: 30))
                                 .fontWeight(.bold)
-                            // 공간을 채움.
+                                .foregroundColor(FontColor.white.color)
                             Spacer()
                         }
-                        // 공간을 채움.
-                        Spacer()
+                        .padding(.top, 40)
                     }
-                    // 텍스트 위와 좌측 여백을 각각 40으로 설정함.
-                    .padding(.top, 40)
-                    .padding(.leading, 40)
-                    .foregroundStyle(LinearGradient(
-                        colors: [Color("ColorFontPurpleStart"), Color("ColorFontPurpleEnd")], startPoint: .top, endPoint: .bottom
-                    ))
-            }
-            // 네 번째 이미지를 표시함.
-            Image("ImgContentSm02")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .overlay {
-                    VStack {
-                        // 이미지 위에 텍스트를 겹침.
-                        Text("오래 가는 배터리")
-                            .font(.system(size: 22))
-                            .fontWeight(.bold)
-                            .foregroundStyle(LinearGradient(
-                                colors: [Color("ColorFontPurpleStart"), Color("ColorFontPurpleEnd")], startPoint: .top, endPoint: .bottom
-                            ))
-                        Text("온종일,")
-                            .font(.system(size: 54))
-                            .fontWeight(.bold)
-                            .foregroundStyle(LinearGradient(
-                                colors: [Color("ColorFontPurpleStart"), Color("ColorFontPurpleEnd")], startPoint: .top, endPoint: .bottom
-                            ))
-                        Text("올인.")
-                            .font(.system(size: 54))
-                            .fontWeight(.bold)
-                            .foregroundStyle(LinearGradient(
-                                colors: [Color("ColorFontPurpleStart"), Color("ColorFontPurpleEnd")], startPoint: .top, endPoint: .bottom
-                            ))
+                
+                Image("ImgContentL02")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .overlay {
+                        VStack {
+                            Text("ProMotion으로 선명한 세상을 만나보세요.")
+                                .font(.system(size: 20))
+                                .fontWeight(.bold)
+                                .foregroundColor(FontColor.white.color)
+                            Text("120Hz의 ProMotion 기술로 더욱 매끄럽고 빠른 화면을 경험하세요.")
+                                .font(.system(size: 16))
+                                .foregroundColor(FontColor.white.color)
+                            Spacer()
+                        }
+                        .padding(.top, 40)
                     }
-            }
-            // 다섯 번째 이미지를 표시함.
-            Image("ImgContentL03")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .overlay {
-                    VStack {
-                        // 이미지 위에 텍스트를 겹침.
-                        Text("상시표시형 디스플레이.\n잠긴 동안에도\n잠드는 법 없이.")
-                        // 공간을 채움.
-                        Spacer()
+                
+                Image("ImgContentL03")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .overlay {
+                        VStack {
+                            Text("그 무엇보다 강력한 카메라.")
+                                .font(.system(size: 20))
+                                .fontWeight(.bold)
+                                .foregroundColor(FontColor.white.color)
+                            Text("더욱 업그레이드된 카메라로 그 어떤 순간도 놓치지 마세요.")
+                                .font(.system(size: 16))
+                                .foregroundColor(FontColor.white.color)
+                            Spacer()
+                        }
+                        .padding(.top, 40)
                     }
-                    // 텍스트 위 여백을 40으로 설정함.
-                    .padding(.top, 40)
-                    .font(.system(size: 24))
-                    .fontWeight(.bold)
-                    .multilineTextAlignment(.center)
-                    .foregroundStyle(LinearGradient(
-                        colors: [Color("ColorFontPurpleStart"), Color("ColorFontPurpleEnd")], startPoint: .top, endPoint: .bottom
-                    ))
-            }
-            // 여섯 번째 이미지를 표시함.
-            Image("ImgContentL04")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .overlay {
-                    VStack {
-                        // 이미지 위에 텍스트를 겹침.
-                        Text("Ceramic Shield")
-                            .font(.system(size: 20))
-                            .fontWeight(.bold)
-                            .foregroundColor(Color("ColorFontGray"))
-                        Text("그 어떤 스마트폰\n글래스보다 견고한 소재.")
-                            .font(.system(size: 24))
-                            .fontWeight(.bold)
-                            .multilineTextAlignment(.center)
-                            .foregroundStyle(LinearGradient(
-                                colors: [Color("ColorFontPurpleStart"), Color("ColorFontPurpleEnd")], startPoint: .top, endPoint: .bottom
-                            ))
-                        // 공간을 채움.
-                        Spacer()
+                
+                Image("ImgContentL04")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .overlay {
+                        VStack {
+                            Text("더욱 강력해진 A16 칩.")
+                                .font(.system(size: 20))
+                                .fontWeight(.bold)
+                                .foregroundColor(FontColor.white.color)
+                            Text("더욱 빠르고, 더욱 효율적인 A16 Bionic.")
+                                .font(.system(size: 16))
+                                .foregroundColor(FontColor.white.color)
+                            Spacer()
+                        }
+                        .padding(.top, 40)
                     }
-                    // 텍스트 위 여백을 40으로 설정함.
-                    .padding(.top, 40)
-                    .foregroundColor(Color("ColorFontWhite"))
+                
+                Image("ImgContentL05")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .overlay {
+                        VStack {
+                            Text("더욱 빠르게, 더욱 편리하게.")
+                                .font(.system(size: 20))
+                                .fontWeight(.bold)
+                                .foregroundColor(FontColor.white.color)
+                            Text("5G의 빠른 속도와 iOS 16의 편의성을 만나보세요.")
+                                .font(.system(size: 16))
+                                .foregroundColor(FontColor.white.color)
+                            Spacer()
+                        }
+                        .padding(.top, 40)
+                    }
             }
         }
-        // 배경색을 설정함.
-        .background(Color("ColorBgBlack"))
+        .background(BgColor.black.color)
     }
 }
 

--- a/week04/pepe/week04_pepe/week04_pepe/MainArea.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/MainArea.swift
@@ -8,81 +8,60 @@
 import SwiftUI
 
 struct MainArea: View {
-    
-    // 다른 색상의 아이템 정보를 저장하는 상태 변수를 선언함.
-    @State var itemOtherColor = itemOtherColors()
-    // 선택된 버튼의 인덱스를 저장하는 상태 변수를 선언함. 초기 값은 0임.
-    @State var selectedButtonIndex: Int = 0
+    @State private var selectedItem = MainAreaItemData.deepPurple
 
     var body: some View {
         ZStack {
-            // 상품 이미지를 표시함.
-            Image(itemOtherColor.imgName)
+            Image(selectedItem.imageName)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .overlay(
                     VStack {
                         
-                        // 상품명과 상품 설명을 표시하는 부분
                         VStack {
                             Text("iPhone 14 Pro")
-                                .foregroundColor(Color("ColorFontWhite"))
+                                .foregroundColor(FontColor.white.color)
                                 .font(.system(size: 20))
                             Text("프로 그 이상.")
-                                .foregroundColor(Color("ColorFontWhite"))
+                                .foregroundColor(FontColor.white.color)
                                 .font(.system(size: 40))
                                 .fontWeight(.bold)
                         }
-                        // 상단 여백을 70으로 설정함.
                         .padding(.top, 70)
                         
                         Spacer()
                         
-                        // 상품 색상명을 표시하는 부분
-                        Text(itemOtherColor.colorName)
-                            .foregroundColor(Color("ColorFontDarkGray"))
+                        Text(selectedItem.rawValue)
+                            .foregroundColor(FontColor.darkGray.color)
                             .font(.system(size: 10))
                             .padding(.bottom, 10)
                         
-                        // 색상 선택 버튼을 생성하는 부분
                         HStack {
-                            // 총 4개의 버튼을 생성함.
-                            ForEach(0..<4) { index in
+                            ForEach(MainAreaItemData.allCases, id: \.self) { item in
                                 Button {
-                                    // 버튼을 눌렀을 때, 상품 이미지, 색상명, 상품명을 업데이트함.
-                                    itemOtherColor.imgName = itemOtherColorArr[index][0]
-                                    itemOtherColor.colorName = itemOtherColorArr[index][1]
-                                    itemOtherColor.imgProductName = itemOtherColorArr[index][3]
-                                    // 선택된 버튼의 인덱스를 업데이트함.
-                                    selectedButtonIndex = index
+                                    selectedItem = item
                                 } label: {
-                                    // 버튼의 디자인을 정의함.
                                     ZStack {
                                         Image(systemName: "circle.fill")
-                                            .foregroundColor(Color(itemOtherColorArr[index][2]))
+                                            .foregroundColor(Color(item.buttonColor))
                                             .font(.system(size: 23))
                                             .overlay(
                                                 Circle()
-                                                    .strokeBorder(selectedButtonIndex == index ? Color.blue : Color.clear, lineWidth: 2)
+                                                    .strokeBorder(selectedItem == item ? BtnColor.blue.color : Color.clear, lineWidth: 2)
                                                     .frame(width: 31, height: 31)
                                             )
                                     }
                                 }
                             }
                         }
-                        // 하단 여백을 20으로 설정함.
                         .padding(.bottom, 20)
                         
-                        // "AR로 보기" 버튼
-                        Button {
-                            EmptyView()
-                        } label: {
+                        Button (action: {}) {
                             HStack {
                                 Text("AR로 보기")
                                 Image(systemName: "arkit")
                             }
                         }
-                        // 하단 여백을 30으로 설정함.
                         .padding(.bottom, 30)
                     }
                 )

--- a/week04/pepe/week04_pepe/week04_pepe/MainView.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/MainView.swift
@@ -8,9 +8,7 @@
 import SwiftUI
 
 struct MainView: View {
-    // 스크롤 위치를 저장하는 상태 변수를 선언함. 초기 값은 CGPoint의 zero임.
     @State private var scrollPosition: CGPoint = .zero
-    // 토스트 메세지 표시 여부를 저장하는 상태 변수를 선언함. 초기 값은 false임.
     @State private var showToast : Bool = false
     
     var body: some View {
@@ -35,26 +33,30 @@ struct MainView: View {
             }
             .coordinateSpace(name: "scroll")
             
-            if self.scrollPosition.y >= -2500 && self.showToast {
+            if showToast && self.scrollPosition.y >= -2500 {
                 ToastView()
                     .transition(.move(edge: .bottom))
-                    .animation(.spring(response: 0.5, dampingFraction: 0.4))
+                    .opacity(showToast ? 1.0 : 0.0)
             }
         }
         .background(scrollPosition.y >= -500 ? BgColor.black.color : BgColor.gray.color)
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.showToast = true
+                withAnimation(.spring(response: 0.5, dampingFraction: 0.4)) {
+                    self.showToast = true
+                }
+            }
+        }
+        .onChange(of: scrollPosition.y) { value in
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.4)) {
+                self.showToast = value >= -2460 ? true : false
             }
         }
     }
 }
 
-// 스크롤 오프셋 값을 저장하기 위한 PreferenceKey를 정의함.
 struct ScrollOffsetPreferenceKey: PreferenceKey {
-    // 기본값은 CGPoint의 zero임.
     static var defaultValue: CGPoint = .zero
-    // reduce 함수는 현재 무시함.
     static func reduce(value: inout CGPoint, nextValue: () -> CGPoint) {
     }
 }

--- a/week04/pepe/week04_pepe/week04_pepe/MainView.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/MainView.swift
@@ -22,33 +22,26 @@ struct MainView: View {
                         .padding(.horizontal, 20)
                     ProductArea()
                 }
-                .background(Color("ColorBgBlack"))
-                // 스크롤 오프셋 값을 기록하기 위해 GeometryReader를 사용함.
-                .background(GeometryReader { geometry in
-                    Color.clear
-                        // ScrollView의 스크롤 위치(origin)를 ScrollOffsetPreferenceKey로 저장함.
-                        .preference(key: ScrollOffsetPreferenceKey.self, value: geometry.frame(in: .named("scroll")).origin)
-                })
-                // 스크롤 위치가 변경될 때 마다, scrollPosition 상태를 업데이트함.
+                .background {
+                    BgColor.black.color
+                    GeometryReader { geometry in
+                        Color.clear
+                            .preference(key: ScrollOffsetPreferenceKey.self, value: geometry.frame(in: .named("scroll")).origin)
+                    }
+                }
                 .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
                     self.scrollPosition = value
                 }
             }
-            // ScrollView의 좌표 공간을 "scroll"로 지정함.
             .coordinateSpace(name: "scroll")
             
-            // 토스트 메세지가 활성화되어 있고 스크롤 위치가 -2500 이상일 때, ToastView를 표시함.
             if self.scrollPosition.y >= -2500 && self.showToast {
                 ToastView()
-                    // ToastView가 화면 바닥에서 위로 올라오는 효과를 줌.
                     .transition(.move(edge: .bottom))
-                    // ToastView의 애니메이션을 설정함.
                     .animation(.spring(response: 0.5, dampingFraction: 0.4))
             }
         }
-        // 배경색을 스크롤 위치에 따라 설정함. 스크롤 위치가 -500 이상일 경우, 배경색을 검은색으로 설정하고, 그렇지 않으면 회색으로 설정함.
-        .background(scrollPosition.y >= -500 ? .black : Color("ColorBgGray"))
-        // View가 화면에 표시되면 토스트 메세지를 표시하는 상태를 참으로 설정함. 딜레이는 0.5초임.
+        .background(scrollPosition.y >= -500 ? BgColor.black.color : BgColor.gray.color)
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.showToast = true

--- a/week04/pepe/week04_pepe/week04_pepe/Model.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/Model.swift
@@ -5,18 +5,77 @@
 //  Created by kimpepe on 2023/06/22.
 //
 
+import SwiftUI
 import Foundation
 
-let itemOtherColorArr = [
-    ["ImgMain01", "딥 퍼플", "ColorBtnDeepPurple", "imgProduct01"],
-    ["ImgMain02", "골드", "ColorBtnGold", "imgProduct02"],
-    ["ImgMain03", "실버", "ColorBtnSliver", "imgProduct03"],
-    ["ImgMain04", "스페이스 블랙", "ColorBtnSpaceBlack", "imgProduct04"]
-]
+enum MainAreaItemData: String, CaseIterable {
+    case deepPurple = "딥 퍼플"
+    case gold = "골드"
+    case silver = "실버"
+    case spaceBlack = "스페이스 블랙"
+    
+    var imageName: String {
+        switch self {
+        case .deepPurple: return "ImgMain01"
+        case .gold: return "ImgMain02"
+        case .silver: return "ImgMain03"
+        case .spaceBlack: return "ImgMain04"
+        }
+    }
+    
+    var buttonColor: String {
+        switch self {
+        case .deepPurple: return "ColorBtnDeepPurple"
+        case .gold: return "ColorBtnGold"
+        case .silver: return "ColorBtnSliver"
+        case .spaceBlack: return "ColorBtnSpaceBlack"
+        }
+    }
+    
+    var productName: String {
+        switch self {
+        case .deepPurple: return "imgProduct01"
+        case .gold: return "imgProduct02"
+        case .silver: return "imgProduct03"
+        case .spaceBlack: return "imgProduct04"
+        }
+    }
+    
+    var color: Color {
+        return Color(buttonColor)
+    }
+}
 
-struct itemOtherColors {
-    var imgName: String = itemOtherColorArr[0][0]
-    var colorName: String = itemOtherColorArr[0][1]
-    var btnColorName: String = itemOtherColorArr[0][2]
-    var imgProductName: String = itemOtherColorArr[0][3]
+enum BgColor: String {
+    case black = "ColorBgBlack"
+    case gray = "ColorBgGray"
+    case white = "ColorBgWhite"
+    
+    var color: Color {
+        return Color(self.rawValue)
+    }
+}
+
+enum BtnColor: String {
+    case sliver = "ColorBtnSliver"
+    case gold = "ColorBtnGold"
+    case spaceBlack = "ColorBtnSpaceBlack"
+    case blue = "ColorBtnBlue"
+    case deepPurple = "ColorBtnDeepPurple"
+
+    var color: Color {
+        return Color(self.rawValue)
+    }
+}
+
+enum FontColor: String {
+    case white = "ColorFontWhite"
+    case darkGray = "ColorFontDarkGray"
+    case gray = "ColorFontGray"
+    case purpleStart = "ColorFontPurpleStart"
+    case purpleEnd = "ColorFontPurpleEnd"
+
+    var color: Color {
+        return Color(self.rawValue)
+    }
 }

--- a/week04/pepe/week04_pepe/week04_pepe/ProductArea.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/ProductArea.swift
@@ -8,10 +8,8 @@
 import SwiftUI
 
 struct ProductArea: View {
-
     var body: some View {
         VStack {
-            // 상단 텍스트와 버튼을 포함한 영역을 만듦.
             Rectangle()
                 .frame(height: 173)
                 .foregroundColor(.white)
@@ -19,36 +17,30 @@ struct ProductArea: View {
                     VStack {
                         Text("iPhone 14 Pro 더 깊이 살펴보기")
                             .font(.system(size: 24))
-                        Button {
-                            EmptyView()  // 버튼을 눌렀을 때 아무 동작도 하지 않음.
-                        } label: {
+                        Button (action: {}) {
                             Text("apple.com에서 더 알아보기")
                                 .font(.system(size: 12))
                         }
                     }
                 }
-            
-            // 상품 이미지를 표시함.
             Image("ImgProduct01")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: .infinity)  // 가능한 최대 너비로 이미지를 표시함.
+                .frame(maxWidth: .infinity)
                 .overlay {
                     VStack {
                         Text("iPhone 14 Pro")
                             .font(.system(size: 26))
                             .fontWeight(.bold)
-                        Spacer()  // 공간을 채움.
-                        Button {
-                            EmptyView()  // 버튼을 눌렀을 때 아무 동작도 하지 않음.
-                        } label: {
+                        Spacer()
+                        Button (action: {}) {
                             Text("구입하기")
                                 .font(.system(size: 14))
                                 .fontWeight(.bold)
-                                .foregroundColor(Color("ColorFontWhite"))
+                                .foregroundColor(FontColor.white.color)
                                 .padding(.vertical, 5)
                                 .padding(.horizontal, 14)
-                                .background(Color("ColorBtnBlue"))
+                                .background(BtnColor.blue.color)
                                 .cornerRadius(20)
                         }
                         Text("₩ 1,550,000부터")
@@ -58,11 +50,8 @@ struct ProductArea: View {
                     .padding(.bottom, 51)
                 }
                 .border(.blue)
-
-            // 공유하기 버튼을 만듦.
-            Button {
-                EmptyView()  // 버튼을 눌렀을 때 아무 동작도 하지 않음.
-            } label: {
+            
+            Button (action: {}) {
                 HStack {
                     Image(systemName: "square.and.arrow.up")
                     Text("공유하기")
@@ -70,19 +59,18 @@ struct ProductArea: View {
                 }
                 .padding(.vertical, 10)
                 .padding(.horizontal, 25)
-                .background(Color("ColorBtnSliver"))
+                .background(BtnColor.sliver.color)
                 .cornerRadius(10)
             }
             .padding(.top, 20)
             
-            // 상품 설명을 표시함.
             Text("1. iPhone 14 Pro 및 iPhone 14 Pro Max는 IEC 규격 60529하의 IP68 (이 문구를 발견하고 톡방에 올리면, 엠선생님의 NearMe 무료 음료수 이용권 증정)")
-                .foregroundColor(Color("ColorFontDarkGray")).
+                .foregroundColor(FontColor.darkGray.color)
                 .font(.system(size: 10))
                 .padding(.horizontal, 10)
                 .padding(.top, 60)
         }
-        .background(Color("ColorBgGray"))
+        .background(BgColor.gray.color)
     }
 }
 

--- a/week04/pepe/week04_pepe/week04_pepe/ToastView.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/ToastView.swift
@@ -12,18 +12,16 @@ struct ToastView: View {
         HStack {
             Text("₩1,250,000부터")
             Spacer()
-            Button {
-                EmptyView()
-            } label: {
+            Button (action: {}) {
                 Text("구입하기")
                     .padding(.horizontal, 20)
                     .padding(.vertical, 6)
             }
-            .background(Color("ColorFontGray"))
+            .background(FontColor.gray.color)
             .cornerRadius(17)
         }
         .padding(20)
-        .background(Color("ColorBtnSliver"))
+        .background(BtnColor.sliver.color)
         .cornerRadius(17)
         .padding(.horizontal)
     }

--- a/week04/pepe/week04_pepe/week04_pepe/week04_pepeApp.swift
+++ b/week04/pepe/week04_pepe/week04_pepe/week04_pepeApp.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@main
+페@main
 struct week04_pepeApp: App {
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
<채드의 피드백>

1. Model, 2차원Array의 필요성
- 색상과 관련된 Asset -> enum으로 모듈화
- MainArea와 관련된 데이터 -> enum으로 모듈화

2. (MainArea 76~ + ProductArea 다수) EmptyView()의 대안
- 빈 클로저로 수정 완료

3. (MainView 25~) .background() 연속 선언의 필요성
- 수정 완료

4. Group 분류
- Asset 중에서 Color 관련 데이터는 수정 완료
- Image 관련 데이터는 필요성이 와닿지 않아 수정X

5. Model 명칭 “itemOtherColor” 의 변경 필요성
- 수정 완료

<개인적인 피드백>
1. animation을 withAnimation으로 수정 완료
2. ToastView의 상태를 판단할 때 -> 삼항 연산자 적용